### PR TITLE
docs: fix typos

### DIFF
--- a/docs/modules/ROOT/pages/user.adoc
+++ b/docs/modules/ROOT/pages/user.adoc
@@ -154,7 +154,7 @@ a|
 
 === Object
 
-`{class-json-object}` wrapper class represens standard JSON object value using SV `string`-indexed associative array of `{class-json-value}`. The class basically wraps standard SV associative array methods with some additional methods required to operate as JSON value.
+`{class-json-object}` wrapper class represents standard JSON object value using SV `string`-indexed associative array of `{class-json-value}`. The class basically wraps standard SV associative array methods with some additional methods required to operate as JSON value.
 
 No additional checks are implemented for "out-of-range" accesses and similar, so you can expect that this class will operate according to behavior of an original underlying SV associative array.
 
@@ -176,7 +176,7 @@ NOTE: SystemVerilog associative array is used to implement JSON object. As a con
 
 === Array
 
-`{class-json-array}` wrapper class represens standard JSON array value using SV queue of `{class-json-value}`.
+`{class-json-array}` wrapper class represents standard JSON array value using SV queue of `{class-json-value}`.
 The class basically wraps standard SV queue methods with some additional methods required to operate as JSON value.
 
 No additional checks are implemented for "out-of-range" accesses and similar,
@@ -196,7 +196,7 @@ so you can expect that this class will operate according to behavior of an origi
 
 === String
 
-`{class-json-string}` wrapper class represens standard JSON string value type using SV string.
+`{class-json-string}` wrapper class represents standard JSON string value type using SV string.
 
 IMPORTANT: `\b` and `\u` escape sequences are not supported.
 
@@ -211,7 +211,7 @@ IMPORTANT: `\b` and `\u` escape sequences are not supported.
 
 ==== Extension: Enum
 
-`{class-json-enum}#(ENUM_T)` wrapper class, that inherits from `{class-json-string}` and represens SV `enum` value as standard JSON string.
+`{class-json-enum}#(ENUM_T)` wrapper class, that inherits from `{class-json-string}` and represents SV `enum` value as standard JSON string.
 The class is parametrized with type `ENUM_T` to work with any enumeration.
 
 Purpose of this class is to facilitate using SV enum with JSON decoder/encoder. For example, JSON values tree can be created with `{class-json-enum}` instances and then they can be seamlessly converted to strings during encoding. And vice versa for decoding.
@@ -230,7 +230,7 @@ Purpose of this class is to facilitate using SV enum with JSON decoder/encoder. 
 
 ==== Extension: Bit Vector
 
-`{class-json-bits}#(BITS_T)` wrapper class, that inherits from `{class-json-string}` and represens SV bit vector value (e.g. `bit[511:0]`) as standard JSON string.
+`{class-json-bits}#(BITS_T)` wrapper class, that inherits from `{class-json-string}` and represents SV bit vector value (e.g. `bit[511:0]`) as standard JSON string.
 The class is parametrized with type `BITS_T` to work with any bit vector - any width, signed or unsigned. Packed structures can be used as well.
 
 Purpose of this class is to facilitate using SV bit vectors of arbitrary size with JSON decoder/encoder.
@@ -256,7 +256,7 @@ JSON standard does not specify requirements for number types, but usually it is 
 
 ==== Integer Number
 
-`{class-json-int}` wrapper class represens JSON integer number value using SV `longint`.
+`{class-json-int}` wrapper class represents JSON integer number value using SV `longint`.
 
 .json_int methods outline
 [cols="1,1"]
@@ -269,7 +269,7 @@ JSON standard does not specify requirements for number types, but usually it is 
 
 ==== Real Number
 
-`{class-json-real}` wrapper class represens JSON real number value using SV `real`.
+`{class-json-real}` wrapper class represents JSON real number value using SV `real`.
 
 .json_real methods outline
 [cols="1,1"]
@@ -282,7 +282,7 @@ JSON standard does not specify requirements for number types, but usually it is 
 
 === Bool
 
-`{class-json-bool}` wrapper class represens standard JSON bool value type using SV `bit`.
+`{class-json-bool}` wrapper class represents standard JSON bool value type using SV `bit`.
 
 .json_bool methods outline
 [cols="1,1"]

--- a/src/json_result.sv
+++ b/src/json_result.sv
@@ -25,7 +25,7 @@ class json_result#(type VAL_T=json_value);
 
   // Create OK result
   static function json_result#(VAL_T) ok(VAL_T value);
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     json_result#(VAL_T) result = new();
     result.value = value;
     return result;
@@ -33,7 +33,7 @@ class json_result#(type VAL_T=json_value);
 
   // Create error result
   static function json_result#(VAL_T) err(json_error error);
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     json_result#(VAL_T) result = new();
     result.error = error;
     return result;
@@ -41,7 +41,7 @@ class json_result#(type VAL_T=json_value);
 
   // Create error result
   virtual function VAL_T unwrap();
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     if (this.is_err()) begin
       this.error.throw_fatal();
     end

--- a/src/values/json_array.sv
+++ b/src/values/json_array.sv
@@ -1,5 +1,5 @@
 // JSON array.
-// This wrapper class represens standard JSON array value using SV queue.
+// This wrapper class represents standard JSON array value using SV queue.
 // The class basically wraps standard SV queue methods with some additional methods required to operate as JSON value.
 // No additional checks are implemented for "out-of-range" accesses and similar,
 // so you can expect that this class will operate according to behavior of an original underlying SV queue.

--- a/src/values/json_bits.sv
+++ b/src/values/json_bits.sv
@@ -61,7 +61,7 @@ class json_bits #(type BITS_T=bit) extends json_string;
 
   // Get internal bit vector value
   virtual function BITS_T get_bits();
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     return this.bits_value;
   endfunction : get_bits
 

--- a/src/values/json_bits.sv
+++ b/src/values/json_bits.sv
@@ -1,5 +1,5 @@
 // JSON bit vector.
-// This wrapper class represens SV bit vector value as standard JSON string.
+// This wrapper class represents SV bit vector value as standard JSON string.
 // Purpose of this class is to facilitate using SV bit vectors of arbitrary size
 // with JSON decoder/encoder. As a result, any number, that cannot be represented
 // as JSON number using longint or real, can be represented as a string.

--- a/src/values/json_bool.sv
+++ b/src/values/json_bool.sv
@@ -1,5 +1,5 @@
 // JSON bool.
-// This wrapper class represens standard JSON bool value type using SV bit.
+// This wrapper class represents standard JSON bool value type using SV bit.
 class json_bool extends json_value implements json_bool_encodable;
   // Internal raw value
   protected bit value;

--- a/src/values/json_enum.sv
+++ b/src/values/json_enum.sv
@@ -1,5 +1,5 @@
 // JSON enum.
-// This wrapper class represens SV enum value as standard JSON string.
+// This wrapper class represents SV enum value as standard JSON string.
 // Purpose of this class is to facilitate using SV enum with JSON decoder/encoder.
 class json_enum #(type ENUM_T) extends json_string;
   // Internal raw value of enum

--- a/src/values/json_enum.sv
+++ b/src/values/json_enum.sv
@@ -10,14 +10,14 @@ class json_enum #(type ENUM_T) extends json_string;
 
   // Create `json_enum` from enum
   static function json_enum#(ENUM_T) from(ENUM_T value);
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     json_enum#(ENUM_T) obj = new(value);
     return obj;
   endfunction : from
 
   // Try to create `json_enum` from string
   static function json_result#(json_enum#(ENUM_T)) try_from(string value);
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     for (ENUM_T e = e.first();; e = e.next()) begin
       if (e.name() == value) begin
         return json_result#(json_enum#(ENUM_T))::ok(json_enum#(ENUM_T)::from(e));
@@ -46,7 +46,7 @@ class json_enum #(type ENUM_T) extends json_string;
 
   // Get internal enum value
   virtual function ENUM_T get_enum();
-    // FIXME: extern is not used here, because verialtor does not work well with parametrized return type
+    // FIXME: extern is not used here, because verilator does not work well with parametrized return type
     return this.enum_value;
   endfunction : get_enum
 

--- a/src/values/json_int.sv
+++ b/src/values/json_int.sv
@@ -1,5 +1,5 @@
 // JSON integer number.
-// This wrapper class represens standard JSON number value using SV longint.
+// This wrapper class represents standard JSON number value using SV longint.
 // JSON does not specify requirements for number types, but it is more
 // convenient to operate with integers and real numbers separately.
 // This class covers integers.

--- a/src/values/json_object.sv
+++ b/src/values/json_object.sv
@@ -1,5 +1,5 @@
 // JSON object.
-// This wrapper class represens standard JSON object value using SV associative array.
+// This wrapper class represents standard JSON object value using SV associative array.
 // The class basically wraps standard SV associative array methods with some additional methods
 // required to operate as JSON value.
 // No additional checks are implemented for "out-of-range" accesses and similar,

--- a/src/values/json_real.sv
+++ b/src/values/json_real.sv
@@ -1,5 +1,5 @@
 // JSON real number.
-// This wrapper class represens standard JSON number value type using SV real.
+// This wrapper class represents standard JSON number value type using SV real.
 // JSON does not specify requirements for number types, but it is more
 // convenient to operate with integers and real numbers separately.
 // This class covers real numbers.

--- a/src/values/json_string.sv
+++ b/src/values/json_string.sv
@@ -1,5 +1,5 @@
 // JSON string.
-// This wrapper class represens standard JSON string value type using SV string.
+// This wrapper class represents standard JSON string value type using SV string.
 class json_string extends json_value implements json_string_encodable;
   // Internal raw value
   protected string value;


### PR DESCRIPTION
"represens" -> "represents"